### PR TITLE
Mistake in the source string

### DIFF
--- a/en/site/tags.json
+++ b/en/site/tags.json
@@ -63,7 +63,7 @@
     },
     "vanilla": {
       "formatted": "Vanilla",
-      "desc": "VVanilla servers aim to recreate Minecraft's original survival gameplay in a multiplayer world. Pure vanilla servers use the server software provided directly by Minecraft and don't have any modifications. Semi-vanilla servers use modified server software and may have a small number of plugins, but only to add simple features that don't significantly change gameplay."
+      "desc": "Vanilla servers aim to recreate Minecraft's original survival gameplay in a multiplayer world. Pure vanilla servers use the server software provided directly by Minecraft and don't have any modifications. Semi-vanilla servers use modified server software and may have a small number of plugins, but only to add simple features that don't significantly change gameplay."
     },
 
     "minigames": {


### PR DESCRIPTION
Also I feel the "Fly mode is enabled as part of the creative mode to allow for easier building _**and servers**_ allow the use of world editing plugins..." is a bit wired. You can change it to "Fly mode is enabled as part of the creative mode to allow for easier building. _**Servers also**_ allow the use of world editing plugins _which makes_ the building process even easier." if it seems better...